### PR TITLE
Fix: README:md file cannot be cloned on Windows machines

### DIFF
--- a/README:md
+++ b/README:md
@@ -1,6 +1,0 @@
-# Video → PPT-Screenshots
-
-1. Clone Repo  
-2. `pip install -r requirements.txt`  
-3. `streamlit run app.py`  
-4. Unter Streamlit Cloud einfach GitHub verlinken!


### PR DESCRIPTION
Detached Fork prematurely, previous PR was closed as a side-effect...
This should help with bringing this fix upstream